### PR TITLE
feat(build): Add runtime image based on Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:latest AS builder
 
 LABEL org.opencontainers.image.source https://github.com/telenornms/skogul
 
@@ -12,4 +12,13 @@ COPY . .
 
 RUN make skogul
 
-ENTRYPOINT ["./skogul"]
+# Runtime
+FROM debian:stable-slim
+
+RUN apt update && apt install -y \
+	ca-certificates
+
+COPY --from=builder /go/src/skogul /usr/local/bin/skogul
+COPY --from=builder /go/src/docs/examples/basics/default.json /etc/skogul/conf.d/default.json
+
+ENTRYPOINT ["skogul", "-loglevel=i"]


### PR DESCRIPTION
Size difference:
\<none\> is an image built using this change,
ghcr.io/telenornms/skogul is v0.18.0 from GHCR.

```
$ podman image ls | grep -e skogul -e e7e56
<none>                                         <none>                    e7e5619d2654  About a minute ago  147 MB
ghcr.io/telenornms/skogul                      v0.18.0                   b10226d1676a  3 months ago        1.07 GB
```